### PR TITLE
Fixed docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM php:8.0-apache
 
-COPY . usr/webinterface/
-WORKDIR usr/webinterface/
+ENV APACHE_DOCUMENT_ROOT /var/www/html/public
 
+COPY . /var/www/html/
+WORKDIR /var/www/html/
+
+# Building the application
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+RUN apt-get update && apt-get install -y git
 RUN composer install --no-dev
 
-USER www-data
+# Enabling ae2 rewrites
+RUN a2enmod rewrite
 
-EXPOSE 80 443
-CMD ["apachectl", "-D", "FOREGROUND"]
+# Change document root
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,6 +65,27 @@ Info: The web interface also works on an external Webspace!
     curl -sS https://getcomposer.org/installer | php
     php composer.phar install --no-dev -o
 
+## Docker
+
+For the docker setup you just need to have `docker` and `git` installed.
+
+## Close the repository
+``git clone https://github.com/The-Systems/CloudNet3-WebInterface.git``
+
+## Build the docker image
+
+``docker build -t cloudnet-webinterface .``
+
+## Run the image
+
+The interface will run on port 8080 on the host.
+
+```bash
+docker run -d --name cloudnet-webinterface \ 
+        --port 8080:80 \
+        cloudnet-webinterface
+```
+
 # GERMAN
 
 ## Vorraussetzungen

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,7 @@ Info: The web interface also works on an external Webspace!
 
 For the docker setup you just need to have `docker` and `git` installed.
 
-## Close the repository
+## Clone the repository
 ``git clone https://github.com/The-Systems/CloudNet3-WebInterface.git``
 
 ## Build the docker image


### PR DESCRIPTION
Hey, I tried to use this project and saw that the Dockerfile doesn't work, so I fixed it.
I made following changes: 
  I first replaced the path with /var/www/html because thats the default path where the apache searches for files and where apps should be hosted in this example
  After that I installed git because composer complained that its missing. That is not a nice solution. Better would be to stage this process into a seperate build stage.
  But I just want to run the interface, so I made it quick and dirty way.
  I also added that ae2 rewrites get enabled and changed the document path to /var/www/html/public.